### PR TITLE
Adapt addNormalizer to symfony tag

### DIFF
--- a/src/NormalizerContainer.php
+++ b/src/NormalizerContainer.php
@@ -14,6 +14,20 @@ class NormalizerContainer
     /** @var NormalizerInterface[] */
     private array $normalizers = [];
 
+    /**
+     * @param iterable<NormalizerInterface> $normalizers
+     */
+    public function __construct(iterable $normalizers)
+    {
+        if ($normalizers instanceof \Traversable) {
+            $normalizers = iterator_to_array($normalizers);
+        }
+
+        foreach ($normalizers as $normalizer) {
+            $this->addNormalizer($normalizer);
+        }
+    }
+
     public function addNormalizer(NormalizerInterface $normalizer): void
     {
         $this->normalizers[$normalizer->getEntityQualifiedName()] = $normalizer;

--- a/tests/Integration/NormalizeTest.php
+++ b/tests/Integration/NormalizeTest.php
@@ -32,13 +32,10 @@ class NormalizeTest extends TestCase
 
     public function provider()
     {
-        $container = new NormalizerContainer();
-
         $dateTimeImmutableNormalizer = new DateTimeImmutableNormalizer();
         $collectionNormalizer = new CollectionNormalizer();
 
-        $container->addNormalizer($dateTimeImmutableNormalizer);
-        $container->addNormalizer($collectionNormalizer);
+        $container = new NormalizerContainer([$dateTimeImmutableNormalizer, $collectionNormalizer]);
         return [
             'Simple' => [
                 new \DateTimeImmutable("@1659967822"),

--- a/tests/Unit/NormalizerContainerTest.php
+++ b/tests/Unit/NormalizerContainerTest.php
@@ -8,7 +8,6 @@ use MosaicHealth\Normalizer\Exception\NormalizerNotFoundException;
 use MosaicHealth\Normalizer\NormalizerInterface;
 use MosaicHealth\Normalizer\NormalizerContainer as SUT;
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
 
 /**
  * @author Hugh O'REILLY <hscoreilly@gmail.com>
@@ -22,8 +21,7 @@ class NormalizerContainerTest extends TestCase
     public function testIsSupportingEntity(array $data, array $expected): void
     {
         // Given
-        $sut = new SUT();
-        $sut->addNormalizer($data['Normalizer']);
+        $sut = new SUT([$data['Normalizer']]);
 
         // When
         $isSupportingEntity = $sut->isSupportingEntity($data['Entity']);
@@ -67,10 +65,11 @@ class NormalizerContainerTest extends TestCase
     public function testGet(array $data, array $expected): void
     {
         // Given
-        $sut = new SUT();
+        $normalizers = [];
         foreach ($data['Normalizers'] as $normalizer) {
-            $sut->addNormalizer($normalizer);
+            $normalizers[] = $normalizer;
         }
+        $sut = new SUT($normalizers);
 
         // When
         if (true === $expected['ExceptionThrown']) {


### PR DESCRIPTION
Symfony tag is giving an iterable as paramater instead of the good
typehint.